### PR TITLE
Update compiler version parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.3.7</version>
+    <version>0.4.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -60,7 +60,7 @@
     </scm>
 
     <properties>
-        <jdk.version>1.8</jdk.version>
+        <maven.compiler.release>1.8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <mainClass>define.in.your.child.pom.for.shading</mainClass>
@@ -84,6 +84,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.coroutines.version>1.3.9</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
+        <kotlin.language.version>1.4</kotlin.language.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.6</jacoco.version>
@@ -550,8 +551,8 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <jvmTarget>1.8</jvmTarget>
-                        <languageVersion>1.4</languageVersion>
+                        <jvmTarget>${maven.compiler.release}</jvmTarget>
+                        <languageVersion>${kotlin.language.version}</languageVersion>
                     </configuration>
                 </plugin>
 
@@ -617,10 +618,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <!-- maven-compiler-plugin defaults to targeting Java 5, but our javac
-                         only supports >=6 -->
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
 
                     <compilerArgs>


### PR DESCRIPTION
`jdk.version` parameter has been replaced with `maven.compiler.release`. updated kotlin compiler plugin to use parameter versions