### PR TITLE
Removed the import scope from the Azure and AWS dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.16.0</version>
+    <version>0.17.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -422,7 +422,6 @@
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>1.11.442</version>
                 <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -460,7 +459,6 @@
                 <artifactId>azure-sdk-bom</artifactId>
                 <version>${azure.bom.version}</version>
                 <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
This was done asthe Azure import scope breaks the transitive dependencies of other projects that import the super pom. Also removed from the aws dependency to make sure it does not cause the same problem at a later stage.

Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>