### PR TITLE
EWB-2866: Update to latest Kotlin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.30.0</version>
+    <version>0.31.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -89,12 +89,12 @@
         <grpc.version>1.57.2</grpc.version>
 
         <!-- Kotlin options -->
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-        <kotlin.coroutines.version>1.5.2</kotlin.coroutines.version>
+        <kotlin.coroutines.version>1.7.1</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.language.version>1.5</kotlin.language.version>
-        <kotlin.serialization.version>1.3.0</kotlin.serialization.version>
+        <kotlin.language.version>1.9</kotlin.language.version>
+        <kotlin.serialization.version>1.6.0</kotlin.serialization.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.7</jacoco.version>
@@ -163,6 +163,16 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
@@ -397,7 +407,7 @@
             <dependency>
                 <groupId>io.mockk</groupId>
                 <artifactId>mockk</artifactId>
-                <version>1.12.7</version>
+                <version>1.12.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
# Description

Updated to latest Kotlin version along with compatible coroutines and serialization versions. Added explicit `kotlin-stdlib-common` and `kotlin-stdlib` dependencies to ensure the matching versions are used.

Downgraded mockk version to 1.12.4 (what other repo's are actually using) since 1.12.7 is broken. Task created to update to mockk-jvm 1.13.x: https://app.clickup.com/t/860rv1f4v

# Associated tasks:

https://github.com/zepben/evolve-sdk-jvm/pull/144
https://github.com/zepben/network-verifier-lib/pull/28
https://github.com/zepben/ewb-network-routes/pull/121
https://github.com/zepben/energy-workbench-server/pull/124
https://github.com/zepben/ewb-network-server/pull/57
https://github.com/zepben/feeder-load-analysis/pull/12
https://github.com/zepben/migrator-sdk/pull/104
https://github.com/zepben/gis-network-extractor/pull/87
https://github.com/zepben/pof-network-extractor/pull/17
https://github.com/zepben/xml-rdf-importer-ausgrid/pull/21
https://github.com/zepben/xml-rdf-importer-ausnet/pull/14
https://github.com/zepben/xml-rdf-importer-endeavour/pull/59
https://github.com/zepben/xml-rdf-importer-evoenergy/pull/28

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~

These you can remove from the list if they are not applicable for this PR.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
