### PR TITLE
[DEV-107] Downgrade Ktor to fix hanging request issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,20 @@
+## [0.35.2]
+
+### Breaking Changes
+* None.
+
+### New Features
+* None.
+
+### Enhancements
+* Downgrade version of Ktor to `2.1.0` to solve issue with Netty and HTTP2, see [KTOR-1516](https://youtrack.jetbrains.com/issue/KTOR-6151/Request-hangs-on-Firefox-with-Netty-HTTPS-and-Compression)
+
+### Fixes
+* None.
+
+### Notes
+* None.
+
 ## [0.35.1]
 
 ### Breaking Changes

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.35.1</version>
+    <version>0.35.2</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -105,7 +105,7 @@
         <skip.integration.tests>true</skip.integration.tests>
 
         <!-- KTOR -->
-        <ktor.version>2.3.8</ktor.version>
+        <ktor.version>2.1.0</ktor.version>
 
         <!-- azure sdk -->
         <azure.bom.version>1.0.5</azure.bom.version>


### PR DESCRIPTION
# Description

Our frontend develpers identified an issue where after running EAS along with its frontend for a while, you would eventually come to a state where requests would have indefinitely until user interaction happened, forcing the next batch of requests to hang. After much investigation, the only solution forward is to downgrade Ktor to 2.1.0. If you'd like to know more keep reading.

During the course of the investigation we found that the bug only occured when using TLS and was replicatable on most browsers, although the easiest one to replicate on was Chrome. It was immediately identified that switching to an older Super POM i.e 0.33 would fix the issue. Super POM 0.34+ had the issue. We noticed that as part of #35 we upgraded Ktor as well.

With experimentation it was determined that Ktor 2.1.0 didn't have the issue. We tried upgrading Ktor in #41 and released Super POM 0.35.1. While it seemed like the issue was resolved, after running the server for a while the issue would happen again.

On the EAS side, the logs showed that the server had responded to all requests quickly even though browsers did not acknowledge this. In order to eliminate any bugs present in a browser, we used Wireshark to sniff the network traffic, and we could see that during a blocked request, there was no response TCP packets sent back from EAS. This further confirmed that it was an EAS/Ktor issue.

Ktor is driven by an underlying server framework Netty, we next sought to eliminate Netty as a suspect. We first tried CIO but it was a non starter as it did not support TLS connections. We then tried to downgrade the Netty used in 2.3.8 to the version in 2.1.0 while still using 2.3.8. This also did not help.

Without any other alternatives, we tried all versions of Ktor between 2.1.0 and 2.3.8 and found that the issue is first introduced in 2.1.1. Examining the [commits](https://github.com/ktorio/ktor/compare/2.1.0...2.1.1), we can see that in 2.1.1, there were a few code changes that were related to Netty and it using HTTP 2. Going back to the network tab in Chrome, we examined the HTTP Protocol used in the requests between the 2 versions and found that in 2.1.0 the browser used HTTP 1.1 while in 2.1.1 it used HTTP 2. Thus we found the culprit.

Looking at the YouTrack issue tracker, we found [KTOR-1516](https://youtrack.jetbrains.com/issue/KTOR-6151/Request-hangs-on-Firefox-with-Netty-HTTPS-and-Compression) which described the issue we were facing which still has not been fixed.

For now, we are downgrading to 2.1.0 until this issue is fixed. Whether the issue, once fixed, will be backported to the KTOR 2.x series is still up for debate. Judging from some other related issues, it seems they are both not accepting issues that are not replicatable in KTOR 3 and, once accepted and fixed, they are not backporting it. So we might have to wait for KTOR 3.

# Associated tasks

- Was upgraded further in #41 
- Initial upgrade in #35 

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [ ] ~I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).

