### PR TITLE
[DEV-5820] Upgrade to Kotlin 2.3 / JVM 17

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -58,11 +58,11 @@ jobs:
           else
             # We're on HEAD, so update the existing image
             echo "commits=HEAD" >> $GITHUB_OUTPUT
-            echo "action_build_container=zepben/pipeline-java-ewb" >> $GITHUB_OUTPUT
+            echo "action_build_container=zepben/pipeline-java-ewb:17-latest" >> $GITHUB_OUTPUT
 
             # We don't have any base commit, so
             # fetch it from the latest image
-            pipeline_java_ewb_labels=$(skopeo inspect docker://zepben/pipeline-java-ewb | jq .Labels)
+            pipeline_java_ewb_labels=$(skopeo inspect docker://zepben/pipeline-java-ewb:17-latest | jq .Labels)
             echo "base_commit=$(echo $pipeline_java_ewb_labels | jq -r '.base_commit')" >> $GITHUB_OUTPUT
 
             # Figure out a version
@@ -211,7 +211,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: zepben/pipeline-java-ewb
+          images: zepben/pipeline-java-ewb:17-latest
           labels: |
             base_commit=${{ needs.parse-inputs.outputs.base_commit }}
             last_commit=${{ needs.parse-inputs.outputs.last_commit }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -13,7 +13,7 @@ on:
         description: If the image should be pushed to the registry
         type: boolean
         default: true
- 
+
 jobs:
   parse-inputs:
     runs-on: ubuntu-latest
@@ -70,11 +70,11 @@ jobs:
               # If our automated dispatch provided a version, use it
               echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
             else
-              # Otherwise, it means we're just rebasing on a new pipeline, 
+              # Otherwise, it means we're just rebasing on a new pipeline,
               # so fetch it from the latest self image
               version=$(echo $pipeline_java_ewb_labels | jq -r '."org.opencontainers.image.version"')
               echo "version=$version" >> $GITHUB_OUTPUT
-            fi 
+            fi
           fi
 
           # set the last commit to whatever caused this flow to run
@@ -85,7 +85,7 @@ jobs:
   build-repository:
     runs-on: ubuntu-latest
     needs: [parse-inputs]
-    container: ${{ needs.parse-inputs.outputs.action_build_container }} 
+    container: ${{ needs.parse-inputs.outputs.action_build_container }}
     env:
       ZEPBEN_GPG_KEY: ${{ secrets.ZEPBEN_GPG_KEY }}
       MAVEN_SETTINGS: ${{ secrets.MAVEN_SETTINGS }}
@@ -128,12 +128,12 @@ jobs:
             # NOTE: This works because 'git reset' doesn't override
             # the untracked files/directories.
             cd local-build
-            ./maven-build.sh 
+            ./maven-build.sh
             cd ..
-          done 
+          done
         shell: bash
 
-      - name: Store repository for wrapping in container  
+      - name: Store repository for wrapping in container
         uses: actions/upload-artifact@v4
         id: upload
         if: steps.build.outcome == 'success'
@@ -222,12 +222,12 @@ jobs:
             type=raw,value=${{ steps.sha.outputs.short_ref }},enable=${{ github.ref_name == 'main' }},priority=200
             type=raw,value=${{ github.ref_name }},enable=${{ github.ref_name != 'main' }},priority=110
             type=raw,value=${{ needs.parse-inputs.outputs.version }},enable=${{ needs.parse-inputs.outputs.version  != '' }},priority=105
-            type=raw,value=latest,enable=${{ github.ref_name == 'main' }},priority=100
+            type=raw,value=17-latest,enable=${{ github.ref_name == 'main' }},priority=100
 
 
       - name: Build and push
         uses: docker/build-push-action@v6
-        env:  
+        env:
           push_image: ${{ contains(null, inputs.push_image) || inputs.push_image }}
         with:
           context: "./for-ci-build-image"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,20 @@
-## [0.47.0]
+## [0.48.0]
+- Super POM now requires JVM 17
+- Upgrade AWS SDK to `2.39.5`
+- Upgrade Azure SDK to `1.3.2`
+- Update all Kotlin dependencies to 2.1
+  - coroutines to 1.10
+  - serialization to 1.19.0
+  - io to 0.8.2
+- Upgrade `mockito` to `5.20.0` and `mockito-kotlin` to `6.1.0`
+- `mockito-inline` was renamed to `mockito-core`
+- Rename `mockk` to `mockk-jvm` and upgrade to `1.14.3`
+- Remove `kotlin-stdlib-common` and `kotlin-stdlin-jdk8` as these have been merged into `kotlin-stdlib` and are no longer necessary
+- Upgrade `maven-compiler-plugin` to `3.14.a` and `error_prone_core` to `2.42.0`
+- Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See <https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default> for more information.
+- Upgrade kotlinx.datetime to `0.7.1-0.6.x-compat`
 
+## [0.47.0]
 - Updated Kotlin from `1.9.10` -> `1.9.24`.
 
 ## [0.46.2]

--- a/changelog.md
+++ b/changelog.md
@@ -2,17 +2,17 @@
 - Super POM now requires JVM 17
 - Upgrade AWS SDK to `2.39.5`
 - Upgrade Azure SDK to `1.3.2`
-- Update all Kotlin dependencies to 2.1
+- Update all Kotlin dependencies to 2.3
   - coroutines to 1.10
   - serialization to 1.19.0
   - io to 0.8.2
 - Upgrade `mockito` to `5.20.0` and `mockito-kotlin` to `6.1.0`
 - `mockito-inline` was renamed to `mockito-core`
-- Rename `mockk` to `mockk-jvm` and upgrade to `1.14.3`
+- Rename `mockk` to `mockk-jvm` and upgrade to `1.14.9`
 - Remove `kotlin-stdlib-common` and `kotlin-stdlin-jdk8` as these have been merged into `kotlin-stdlib` and are no longer necessary
 - Upgrade `maven-compiler-plugin` to `3.14.a` and `error_prone_core` to `2.42.0`
 - Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See <https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default> for more information.
-- Upgrade kotlinx.datetime to `0.7.1-0.6.x-compat`
+- Upgrade kotlinx.datetime to `0.7.1`
 
 ## [0.47.0]
 - Updated Kotlin from `1.9.10` -> `1.9.24`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,16 @@
 ## [0.48.0]
 - Super POM now requires JVM 17
-- Upgrade AWS SDK to `2.39.5`
-- Upgrade Azure SDK to `1.3.2`
-- Update all Kotlin dependencies to 2.3
+- Upgrade AWS SDK to `2.42.18`
+- Upgrade Azure SDK to `1.3.5`
+- Update all Kotlin dependencies to 2.3.20
   - coroutines to 1.10
   - serialization to 1.19.0
-  - io to 0.8.2
-- Upgrade `mockito` to `5.20.0` and `mockito-kotlin` to `6.1.0`
+  - io to 0.9.0
+- Upgrade `mockito` to `5.23.0` and `mockito-kotlin` to `6.3.0`
 - `mockito-inline` was renamed to `mockito-core`
 - Rename `mockk` to `mockk-jvm` and upgrade to `1.14.9`
 - Remove `kotlin-stdlib-common` and `kotlin-stdlin-jdk8` as these have been merged into `kotlin-stdlib` and are no longer necessary
-- Upgrade `maven-compiler-plugin` to `3.14.a` and `error_prone_core` to `2.42.0`
-- Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See <https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default> for more information.
+- Upgrade `maven-compiler-plugin` to `3.14.1` and `error_prone_core` to `2.42.0`
 - Upgrade kotlinx.datetime to `0.7.1`
 - Upgrade hadoop dependencies to `3.4.2`
 - Upgrade parquet dependencies to `1.17.0`

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - Upgrade kotlinx.datetime to `0.7.1`
 - Upgrade hadoop dependencies to `3.4.2`
 - Upgrade parquet dependencies to `1.17.0`
+- Upgrade Avro to `2.10.0`
 
 ## [0.47.0]
 - Updated Kotlin from `1.9.10` -> `1.9.24`.

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - Upgrade `maven-compiler-plugin` to `3.14.a` and `error_prone_core` to `2.42.0`
 - Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See <https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default> for more information.
 - Upgrade kotlinx.datetime to `0.7.1`
+- Upgrade hadoop dependencies to `3.4.2`
 
 ## [0.47.0]
 - Updated Kotlin from `1.9.10` -> `1.9.24`.

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See <https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default> for more information.
 - Upgrade kotlinx.datetime to `0.7.1`
 - Upgrade hadoop dependencies to `3.4.2`
+- Upgrade parquet dependencies to `1.17.0`
 
 ## [0.47.0]
 - Updated Kotlin from `1.9.10` -> `1.9.24`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## [0.48.0]
-- Super POM now requires JVM 17
+- Super POM now requires JVM 17, therefore projects that use this version will need JVM 17 to compile
 - Upgrade AWS SDK to `2.42.18`
 - Upgrade Azure SDK to `1.3.5`
 - Update all Kotlin dependencies to 2.3.20

--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,10 @@
         <ktor.version>3.0.3</ktor.version>
 
         <!-- azure sdk -->
-        <azure.bom.version>1.2.30</azure.bom.version>
+        <azure.bom.version>1.3.2</azure.bom.version>
 
         <!-- aws sdk -->
-        <aws.sdk.version>2.27.21</aws.sdk.version>
+        <aws.sdk.version>2.39.5</aws.sdk.version>
 
         <dokka.version>1.9.20</dokka.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 
         <sis.version>1.0</sis.version>
 
-        <hadoop.version>3.4.1</hadoop.version>
+        <hadoop.version>3.4.2</hadoop.version>
 
         <temporal.version>1.25.2</temporal.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <sis.version>1.0</sis.version>
 
         <hadoop.version>3.4.2</hadoop.version>
+        <parquet.version>1.17.0</parquet.version>
 
         <temporal.version>1.25.2</temporal.version>
 
@@ -508,12 +509,12 @@
             <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-common</artifactId>
-                <version>1.13.0</version>
+                <version>${parquet.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-avro</artifactId>
-                <version>1.13.0</version>
+                <version>${parquen.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.avro-kotlin.avro4k</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
             <dependency>
                 <groupId>io.mockk</groupId>
                 <artifactId>mockk-jvm</artifactId>
-                <version>1.13.17</version>
+                <version>1.14.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-datetime-jvm</artifactId>
-                <version>0.7.1</version>
+                <version>0.7.1-0.6.x-compat</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -261,7 +261,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -615,7 +615,7 @@
             <dependency>
                 <groupId>io.mockk</groupId>
                 <artifactId>mockk-jvm</artifactId>
-                <version>1.14.6</version>
+                <version>1.13.17</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1196,7 +1196,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
 
@@ -1204,13 +1204,15 @@
                         <!-- XXX: all Error Prone args should come in a single argument -->
                         <arg>-XDcompilePolicy=byfile</arg>
                         <arg>-Xlint:unchecked</arg>
-                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode</arg>
+                        <arg>--should-stop=ifError=FLOW</arg>
+                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED -J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <annotationProcessorPath>
                             <groupId>com.google.errorprone</groupId>
                             <artifactId>error_prone_core</artifactId>
-                            <version>2.3.4</version>
+                            <version>2.42.0</version>
                         </annotationProcessorPath>
                         <annotationProcessorPath>
                             <groupId>com.google.auto.value</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,12 @@
 
         <!-- Kotlin options -->
         <kotlin.version>1.9.24</kotlin.version>
+        <kotlin.version>2.2.21</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-        <kotlin.coroutines.version>1.7.1</kotlin.coroutines.version>
+        <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.language.version>1.9</kotlin.language.version>
-        <kotlin.serialization.version>1.6.0</kotlin.serialization.version>
+	<kotlin.language.version>2.1</kotlin.language.version>
+        <kotlin.serialization.version>1.9.0</kotlin.serialization.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.7</jacoco.version>
@@ -240,7 +241,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-io-core-jvm</artifactId>
-                <version>0.6.0</version>
+                <version>0.8.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
@@ -255,7 +256,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-datetime-jvm</artifactId>
-                <version>0.6.1</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <vertx.version>4.5.11</vertx.version>
 
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
-        <mockito.version>3.12.4</mockito.version>
-        <mockito.kotlin.version>3.2.0</mockito.kotlin.version>
+        <mockito.version>5.20.0</mockito.version>
+        <mockito.kotlin.version>6.1.0</mockito.kotlin.version>
         <hamcrest.version>2.2</hamcrest.version>
         <graphql-java.version>21.3</graphql-java.version>
         <graphql-kotlin.version>6.5.6</graphql-kotlin.version>
@@ -89,12 +89,11 @@
         <grpc.version>1.71.0</grpc.version>
 
         <!-- Kotlin options -->
-        <kotlin.version>1.9.24</kotlin.version>
         <kotlin.version>2.2.21</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
-	<kotlin.language.version>2.1</kotlin.language.version>
+        <kotlin.language.version>2.1</kotlin.language.version>
         <kotlin.serialization.version>1.9.0</kotlin.serialization.version>
 
         <!-- jacoco options -->
@@ -215,17 +214,7 @@
             <!-- Kotlin -->
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
@@ -625,8 +614,8 @@
             </dependency>
             <dependency>
                 <groupId>io.mockk</groupId>
-                <artifactId>mockk</artifactId>
-                <version>1.12.4</version>
+                <artifactId>mockk-jvm</artifactId>
+                <version>1.14.6</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1178,7 +1167,10 @@
                                 <sourceDirs>
                                     <source>src/test/java</source>
                                     <source>src/test/kotlin</source>
-                                </sourceDirs>
+        			</sourceDirs>
+				<args>
+				  <arg>-Xlambdas=class</arg>
+				</args>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <kotlin.language.version>2.3</kotlin.language.version>
         <kotlin.serialization.version>1.10.0</kotlin.serialization.version>
         <kotlin.io.version>0.9.0</kotlin.io.version>
+        <kotlin.datetime.version>0.7.1</kotlin.datetime.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.7</jacoco.version>
@@ -247,7 +248,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-datetime-jvm</artifactId>
-                <version>0.7.1</version>
+                <version>${kotlin.datetime.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.zepben.maven</groupId>
@@ -193,8 +193,7 @@
             <!-- OpenTelemetry -->
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
-                <artifactId
-                >opentelemetry-instrumentation-annotations</artifactId>
+                <artifactId>opentelemetry-instrumentation-annotations</artifactId>
                 <version>${opentelemetry.annotation.version}</version>
             </dependency>
 
@@ -734,7 +733,8 @@
                 <version>1.24.1</version>
             </dependency>
 
-            <!-- coordinate systems - not sure why we have so many different ones of these, probably needs to be consolidated -->
+            <!-- coordinate systems - not sure why we have so many different ones of these, probably
+            needs to be consolidated -->
             <dependency>
                 <groupId>mil.nga.geopackage</groupId>
                 <artifactId>geopackage-core</artifactId>
@@ -856,7 +856,8 @@
             </dependency>
 
 
-            <!--Vert.x packages-->
+            <!--Vert.x
+            packages-->
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-core</artifactId>
@@ -919,7 +920,8 @@
                 <scope>test</scope>
             </dependency>
 
-            <!--AWS packages-->
+            <!--AWS
+            packages-->
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-lambda-java-core</artifactId>
@@ -1036,10 +1038,15 @@
     </dependencyManagement>
 
     <dependencies>
-        <!--THINK CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
-        <!--NO ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
+        <!--THINK
+        CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE
+        INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
+        <!--NO
+        ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE
+        SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
 
-        <!--Test Utils-->
+        <!--Test
+        Utils-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
@@ -1071,7 +1078,8 @@
             <scope>test</scope>
         </dependency>
 
-        <!--Add coverage to all projects-->
+        <!--Add
+        coverage to all projects-->
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
@@ -1080,8 +1088,12 @@
             <scope>test</scope>
         </dependency>
 
-        <!--THINK CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
-        <!--NO ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
+        <!--THINK
+        CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE
+        INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
+        <!--NO
+        ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE
+        SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
     </dependencies>
 
     <build>
@@ -1107,7 +1119,8 @@
                             </goals>
                             <configuration>
                                 <transformers>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <manifestEntries>
                                             <Main-Class>${mainClass}</Main-Class>
                                             <Specification-Title>${project.artifactId}</Specification-Title>
@@ -1117,9 +1130,10 @@
                                             <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                                         </manifestEntries>
                                     </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                    <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 </transformers>
-                                <artifactSet/>
+                                <artifactSet />
                                 <filters>
                                     <filter>
                                         <artifact>*:*</artifact>
@@ -1167,10 +1181,10 @@
                                 <sourceDirs>
                                     <source>src/test/java</source>
                                     <source>src/test/kotlin</source>
-        			</sourceDirs>
-				<args>
-				  <arg>-Xlambdas=class</arg>
-				</args>
+                                </sourceDirs>
+                                <args>
+                                    <arg>-Xlambdas=class</arg>
+                                </args>
                             </configuration>
                         </execution>
                     </executions>
@@ -1183,7 +1197,9 @@
         </pluginManagement>
 
         <plugins>
-            <!--THINK CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT SECTION!-->
+            <!--THINK
+            CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT
+            SECTION!-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -1205,7 +1221,17 @@
                         <arg>-XDcompilePolicy=byfile</arg>
                         <arg>-Xlint:unchecked</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED -J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+                            -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                            -J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+                            -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
 
                     </compilerArgs>
                     <annotationProcessorPaths>
@@ -1223,7 +1249,8 @@
                 </configuration>
             </plugin>
 
-            <!-- This plugin enforces that release version projects do not have any dependencies that are snapshots -->
+            <!-- This plugin enforces that release version projects do not have any dependencies
+            that are snapshots -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -1374,7 +1401,11 @@
                 <version>3.0.0-M3</version>
                 <configuration>
                     <!-- Sets the VM argument line used when unit tests are run. -->
-                    <argLine>${surefireArgLine} -Dfile.encoding=UTF-8</argLine>
+                    <!-- add-opens flags are to allow mocking of Java final private fields -->
+                    <argLine>
+                        ${surefireArgLine} -Dfile.encoding=UTF-8
+                    </argLine>
+
                     <!-- Skips unit tests if the value of skip.unit.tests property is true -->
                     <skipTests>${skip.unit.tests}</skipTests>
                     <!-- Excludes integration tests when unit tests are run. -->
@@ -1420,7 +1451,8 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <!-- Add "src/main/kotlin" as additional source directory, so that jacoco-maven-plugin
+                        <!-- Add "src/main/kotlin" as additional source directory, so that
+                        jacoco-maven-plugin
                         (or other plugins that care about sources) will look for files in it -->
                         <id>add-source</id>
                         <phase>generate-sources</phase>
@@ -1449,7 +1481,9 @@
             </plugin>
 
 
-            <!--THINK CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT SECTION!-->
+            <!--THINK
+            CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT
+            SECTION!-->
         </plugins>
 
     </build>
@@ -1486,7 +1520,8 @@
                         </configuration>
                     </plugin>
 
-                    <!-- Sign artifacts with gpg. Requires gpg command to be available and creds configured in settings.xml
+                    <!-- Sign artifacts with gpg. Requires gpg command to be available and creds
+                    configured in settings.xml
     See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -1513,14 +1548,14 @@
 
                     <!-- Plugin for deploying to maven central -->
                     <plugin>
-                      <groupId>org.sonatype.central</groupId>
-                      <artifactId>central-publishing-maven-plugin</artifactId>
-                      <version>0.8.0</version>
-                      <extensions>true</extensions>
-                      <configuration>
-                        <publishingServerId>maven-central</publishingServerId>
-                        <autoPublish>true</autoPublish>
-                      </configuration>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>maven-central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>com.zepben.maven</groupId>
     <artifactId>evolve-super-pom</artifactId>
     <!-- Version should not be set to snapshot as CI expects finalized version -->
-    <version>0.47.0</version>
+    <version>0.48.0</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
 
         <hadoop.version>3.4.2</hadoop.version>
         <parquet.version>1.17.0</parquet.version>
+        <avro.version>2.10.0</avro.version>
 
         <temporal.version>1.25.2</temporal.version>
 
@@ -514,12 +515,12 @@
             <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-avro</artifactId>
-                <version>${parquen.version}</version>
+                <version>${parquet.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.avro-kotlin.avro4k</groupId>
                 <artifactId>avro4k-core</artifactId>
-                <version>1.10.0</version>
+                <version>${avro.version}</version>
             </dependency>
 
             <!-- Hadoop -->

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <vertx.version>4.5.11</vertx.version>
 
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
-        <mockito.version>5.20.0</mockito.version>
-        <mockito.kotlin.version>6.1.0</mockito.kotlin.version>
+        <mockito.version>5.23.0</mockito.version>
+        <mockito.kotlin.version>6.3.0</mockito.kotlin.version>
         <hamcrest.version>2.2</hamcrest.version>
         <graphql-java.version>21.3</graphql-java.version>
         <graphql-kotlin.version>6.5.6</graphql-kotlin.version>
@@ -95,6 +95,7 @@
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.language.version>2.3</kotlin.language.version>
         <kotlin.serialization.version>1.10.0</kotlin.serialization.version>
+        <kotlin.io.version>0.9.0</kotlin.io.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.7</jacoco.version>
@@ -231,7 +232,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-io-core-jvm</artifactId>
-                <version>0.8.2</version>
+                <version>${kotlin.io.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,12 @@
         <grpc.version>1.71.0</grpc.version>
 
         <!-- Kotlin options -->
-        <kotlin.version>2.2.21</kotlin.version>
+        <kotlin.version>2.3.10</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.language.version>2.1</kotlin.language.version>
-        <kotlin.serialization.version>1.9.0</kotlin.serialization.version>
+        <kotlin.language.version>2.3</kotlin.language.version>
+        <kotlin.serialization.version>1.10.0</kotlin.serialization.version>
 
         <!-- jacoco options -->
         <jacoco.version>0.8.7</jacoco.version>
@@ -244,7 +244,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-datetime-jvm</artifactId>
-                <version>0.7.1-0.6.x-compat</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
             <dependency>
                 <groupId>io.mockk</groupId>
                 <artifactId>mockk-jvm</artifactId>
-                <version>1.14.4</version>
+                <version>1.14.9</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <grpc.version>1.71.0</grpc.version>
 
         <!-- Kotlin options -->
-        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
         <kotlin.code.style>official</kotlin.code.style>
@@ -108,10 +108,10 @@
         <ktor.version>3.0.3</ktor.version>
 
         <!-- azure sdk -->
-        <azure.bom.version>1.3.2</azure.bom.version>
+        <azure.bom.version>1.3.5</azure.bom.version>
 
         <!-- aws sdk -->
-        <aws.sdk.version>2.39.5</aws.sdk.version>
+        <aws.sdk.version>2.42.18</aws.sdk.version>
 
         <dokka.version>1.9.20</dokka.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1169,13 +1169,6 @@
                                     <source>src/test/java</source>
                                     <source>src/test/kotlin</source>
                                 </sourceDirs>
-                                <args>
-                                    <!--
-                                        This generates anonymous classes for lambdas like in Kotlin 1.9
-                                        This is to allow lambda's to be spyk/mockk without putting annotations everywhere
-                                    -->
-                                    <arg>-Xlambdas=class</arg>
-                                </args>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.zepben.maven</groupId>
@@ -733,8 +733,7 @@
                 <version>1.24.1</version>
             </dependency>
 
-            <!-- coordinate systems - not sure why we have so many different ones of these, probably
-            needs to be consolidated -->
+            <!-- coordinate systems - not sure why we have so many different ones of these, probably needs to be consolidated -->
             <dependency>
                 <groupId>mil.nga.geopackage</groupId>
                 <artifactId>geopackage-core</artifactId>
@@ -856,8 +855,7 @@
             </dependency>
 
 
-            <!--Vert.x
-            packages-->
+            <!--Vert.x packages-->
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-core</artifactId>
@@ -920,8 +918,7 @@
                 <scope>test</scope>
             </dependency>
 
-            <!--AWS
-            packages-->
+            <!--AWS packages-->
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-lambda-java-core</artifactId>
@@ -1038,15 +1035,10 @@
     </dependencyManagement>
 
     <dependencies>
-        <!--THINK
-        CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE
-        INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
-        <!--NO
-        ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE
-        SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
+        <!--THINK CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
+        <!--NO ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
 
-        <!--Test
-        Utils-->
+        <!--Test Utils-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
@@ -1078,8 +1070,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!--Add
-        coverage to all projects-->
+        <!--Add coverage to all projects-->
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
@@ -1088,12 +1079,8 @@
             <scope>test</scope>
         </dependency>
 
-        <!--THINK
-        CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE
-        INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
-        <!--NO
-        ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE
-        SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
+        <!--THINK CAREFULLY ABOUT PUTTING DEPENDENCIES HERE. DEFINE THEM IN DEPENDENCY MANAGEMENT AND LET THE INDIVIDUAL MODULE DECIDE IF IT NEEDS IT!-->
+        <!--NO ZEPBEN PRODUCED LIBRARIES SHOULD BE INCLUDED HERE AS THEY SHOULD ALL BE REFERENCING THE SUPER POM AND THAT WILL CREATE CYCLIC REFERENCES!-->
     </dependencies>
 
     <build>
@@ -1119,8 +1106,7 @@
                             </goals>
                             <configuration>
                                 <transformers>
-                                    <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <manifestEntries>
                                             <Main-Class>${mainClass}</Main-Class>
                                             <Specification-Title>${project.artifactId}</Specification-Title>
@@ -1130,10 +1116,9 @@
                                             <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                                         </manifestEntries>
                                     </transformer>
-                                    <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 </transformers>
-                                <artifactSet />
+                                <artifactSet/>
                                 <filters>
                                     <filter>
                                         <artifact>*:*</artifact>
@@ -1183,6 +1168,10 @@
                                     <source>src/test/kotlin</source>
                                 </sourceDirs>
                                 <args>
+                                    <!--
+                                        This generates anonymous classes for lambdas like in Kotlin 1.9
+                                        This is to allow lambda's to be spyk/mockk without putting annotations everywhere
+                                    -->
                                     <arg>-Xlambdas=class</arg>
                                 </args>
                             </configuration>
@@ -1197,9 +1186,7 @@
         </pluginManagement>
 
         <plugins>
-            <!--THINK
-            CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT
-            SECTION!-->
+            <!--THINK CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT SECTION!-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -1221,18 +1208,7 @@
                         <arg>-XDcompilePolicy=byfile</arg>
                         <arg>-Xlint:unchecked</arg>
                         <arg>--should-stop=ifError=FLOW</arg>
-                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-                            -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-                            -J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-                            -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-
+                        <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode</arg>
                     </compilerArgs>
                     <annotationProcessorPaths>
                         <annotationProcessorPath>
@@ -1249,8 +1225,7 @@
                 </configuration>
             </plugin>
 
-            <!-- This plugin enforces that release version projects do not have any dependencies
-            that are snapshots -->
+            <!-- This plugin enforces that release version projects do not have any dependencies that are snapshots -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -1401,11 +1376,7 @@
                 <version>3.0.0-M3</version>
                 <configuration>
                     <!-- Sets the VM argument line used when unit tests are run. -->
-                    <!-- add-opens flags are to allow mocking of Java final private fields -->
-                    <argLine>
-                        ${surefireArgLine} -Dfile.encoding=UTF-8
-                    </argLine>
-
+                    <argLine>${surefireArgLine} -Dfile.encoding=UTF-8</argLine>
                     <!-- Skips unit tests if the value of skip.unit.tests property is true -->
                     <skipTests>${skip.unit.tests}</skipTests>
                     <!-- Excludes integration tests when unit tests are run. -->
@@ -1451,8 +1422,7 @@
                 <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <!-- Add "src/main/kotlin" as additional source directory, so that
-                        jacoco-maven-plugin
+                        <!-- Add "src/main/kotlin" as additional source directory, so that jacoco-maven-plugin
                         (or other plugins that care about sources) will look for files in it -->
                         <id>add-source</id>
                         <phase>generate-sources</phase>
@@ -1481,9 +1451,7 @@
             </plugin>
 
 
-            <!--THINK
-            CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT
-            SECTION!-->
+            <!--THINK CAREFULLY ABOUT PUTTING PLUGINS HERE. YOU WILL LIKELY WANT IT IN THE PLUGIN MANAGEMENT SECTION!-->
         </plugins>
 
     </build>
@@ -1520,8 +1488,7 @@
                         </configuration>
                     </plugin>
 
-                    <!-- Sign artifacts with gpg. Requires gpg command to be available and creds
-                    configured in settings.xml
+                    <!-- Sign artifacts with gpg. Requires gpg command to be available and creds configured in settings.xml
     See: https://central.sonatype.org/pages/apache-maven.html#gpg-signed-components -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -1548,14 +1515,14 @@
 
                     <!-- Plugin for deploying to maven central -->
                     <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <publishingServerId>maven-central</publishingServerId>
-                            <autoPublish>true</autoPublish>
-                        </configuration>
+                      <groupId>org.sonatype.central</groupId>
+                      <artifactId>central-publishing-maven-plugin</artifactId>
+                      <version>0.8.0</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                        <publishingServerId>maven-central</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                      </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
# Description

Time to do some upgrades. 

This PR upgrades the super pom to Kotlin 2.3 and does some other misc changes in order to support this upgrade.

> [!IMPORTANT]  
> See changelog in PR for up to date dependency versions

- Upgrade to latest AWS/Azure - always good to stay up to date on this as these dependencies get bumped at the drop of a hat
- Update all Kotlin dependencies to 2.3 -
    - coroutines to 1.10
    - serialization to 1.19.0
    - io to 0.8.2
- Upgrade mockito the latest to support weird bytecode changes, also `mockito-inline` is now just `mockito-core`
- Rename `mockk` to `mockk-jvm` as they have done so upstream
- Remove `kotlin-stdlib-common` and `kotlin-stdlin-jdk8` as these have been merged into `kotlin-stdlib` and are no longer necessary
- Upgrade mockk to 1.14.9 to support changes, this requires that we now use JVM 17 instead of 11
- Upgrade maven-compiler-plugin and `error_prone_core` to support JVM 17
- Add argument `-Xlambdas=class` in tests to continue support using `mockk` on lambdas. See https://youtrack.jetbrains.com/issue/KTLC-10/Generate-all-Kotlin-lambdas-via-invokedynamic-LambdaMetafactory-by-default for more information. This means that lambdas on real code will use the new feature, while test lambdas will use the old way. If there is a lambda in real code that needs mocking, then the `@JvmSerializableLambda` annotation will need to be added.
- Upgrade kotlinx.datetime to `0.7.1` - See https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant for more details

Also important to note that JVM 17 requires that `~/.mvn/jvm.config` (new file) contain the following

```
--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
```

This is due to the introduction of Java modules in JVM 17. See https://openjdk.org/projects/jigsaw/ for more information.

Additionally, from henceforth, we bump change the image tagging such that instead of latest, we tag as `17-latest`. This is to allow projects that haven't migrated to stay on 11 until they opt-in. Of course, it requires us to retag that current `latest` image to `11-latest` manually before merging this PR. 

# Test Steps

:cut_of_meat: 

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

What is breaking really?
